### PR TITLE
import only used QtCore modules

### DIFF
--- a/treenote/model.py
+++ b/treenote/model.py
@@ -4,7 +4,7 @@
 # TreeNote
 # A collaboratively usable outliner for personal knowledge and task management.
 ##
-# Copyright (C) 2015 Jan Korte (jan.korte@uni-oldenburg.de)
+# Copyright (C) 2015-2017 Jan Korte (jan.korte@uni-oldenburg.de)
 ##
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +16,8 @@ import re
 import sys
 from xml.sax.saxutils import escape
 
-from PyQt5.QtCore import *
+from PyQt5.QtCore import (QAbstractItemModel, QModelIndex,
+                          QSortFilterProxyModel, QSize, Qt)
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 

--- a/treenote/planned_model.py
+++ b/treenote/planned_model.py
@@ -1,4 +1,16 @@
-from PyQt5.QtCore import *
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# TreeNote
+# A collaboratively usable outliner for personal knowledge and task management.
+#
+# Copyright (C) 2015-2017 Jan Korte (j.korte@me.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+
+from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
 
 
 class PlannedModel(QAbstractItemModel):

--- a/treenote/tag_model.py
+++ b/treenote/tag_model.py
@@ -1,4 +1,16 @@
-from PyQt5.QtCore import *
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# TreeNote
+# A collaboratively usable outliner for personal knowledge and task management.
+#
+# Copyright (C) 2015-2017 Jan Korte (j.korte@me.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+
+from PyQt5.QtCore import QAbstractItemModel, QModelIndex, QtQt
 
 import treenote.model as model
 

--- a/treenote/tag_model.py
+++ b/treenote/tag_model.py
@@ -10,7 +10,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, version 3 of the License.
 
-from PyQt5.QtCore import QAbstractItemModel, QModelIndex, QtQt
+from PyQt5.QtCore import QAbstractItemModel, QModelIndex, Qt
 
 import treenote.model as model
 


### PR DESCRIPTION
It is recommended to not to use import * in Python, so I change that only load the used module, maybe save a little memory and faster starting time. And I copy the header to the file and change the date.